### PR TITLE
Serial port timer added, HCN current reset added

### DIFF
--- a/dynamic_clamp/HCN.ino
+++ b/dynamic_clamp/HCN.ino
@@ -3,8 +3,8 @@
 // and put in lookup tables stored as global variables.
 
 // Declare the lookup table variables
-float sinf1[1501] = {0.0};                                     // Pre-calculate the activation parameters for
-float tau1[1501] = {0.0};                                      // HCN currents: Vm from -100 mV to +50 mV in
+float sinf1[1501] = {0.0};                                    // Pre-calculate the activation parameters for
+float tau1[1501] = {0.0};                                     // HCN currents: Vm from -100 mV to +50 mV in
                                                               // steps of 0.1 mV
 // Generate the lookup tables
 void GenerateHcnLUT() {
@@ -17,14 +17,19 @@ void GenerateHcnLUT() {
 }
 
 // At every time step, calculate the HCN current in the Hodgkin-Huxley manner
-float HCN(float v) {
-  static float sVar = 0.0;                                    // activation gate
-  float v10 = v*10.0;
-  int vIdx = (int)v10 + 1000;
-  vIdx = constrain(vIdx,0,1500);
-  sVar = sVar + dt * ( -(sVar-sinf1[vIdx])/tau1[vIdx] );      // forward Euler method
-  if (sVar<0.0) sVar=0.0;                                     // non-negative only
-  float current = -gH * sVar * (v + 30);                      // injected current (pA) 
-  return current;
+float HCN(float v, float gH) {
+  static float sVar = 0.0;                                    // initialize activation gate, executed once
+  if (gH==0.0) {
+    sVar = 0.0;                                               // reset activation gate before next run
+    return 0.0;
+  } else {
+    float v10 = v*10.0;
+    int vIdx = (int)v10 + 1000;
+    vIdx = constrain(vIdx,0,1500);
+    sVar = sVar + dt * ( -(sVar-sinf1[vIdx])/tau1[vIdx] );      // forward Euler method
+    if (sVar<0.0) sVar=0.0;                                     // non-negative only
+    float current = -gH * sVar * (v + 30);                      // injected current (pA) 
+    return current;
+  }
 }
 


### PR DESCRIPTION
* The serial port is now checked frequently (100 ms) for conductance changes from the users, freeing CPU ressources for other purposes.
* The activation gate for the HCN current will now properly be reset, when the conductance is set to zero - i.e. when repeating noncontinuous experiments with different conductance values, which are interrupted by intervals without current injection (controls).
