### PR TITLE
Update dynamic_clamp.ino

### DIFF
--- a/dynamic_clamp/dynamic_clamp.ino
+++ b/dynamic_clamp/dynamic_clamp.ino
@@ -50,7 +50,7 @@ const float gain_OUTPUT = 400.0;                  // number of picoamps injected
 const float inputSlope = 5.5010/gain_INPUT;      
 const float inputIntercept = -10922.73/gain_INPUT;    
 const float outputSlope = 753/gain_OUTPUT;       
-const float outputIntercept = 2386/gain_OUTPUT;
+const float outputIntercept = 2386;
 
 // Conductance parameters are sent by the host computer over the USB port
 const int nPars = 8;              // number of adjustable parameters

--- a/dynamic_clamp/dynamic_clamp.ino
+++ b/dynamic_clamp/dynamic_clamp.ino
@@ -50,7 +50,7 @@ const float gain_OUTPUT = 400.0;                  // number of picoamps injected
 const float inputSlope = 5.5010/gain_INPUT;      
 const float inputIntercept = -10922.73/gain_INPUT;    
 const float outputSlope = 753/gain_OUTPUT;       
-const float outputIntercept = 2386;
+const float outputIntercept = 2386/gain_OUTPUT;
 
 // Conductance parameters are sent by the host computer over the USB port
 const int nPars = 8;              // number of adjustable parameters


### PR DESCRIPTION
I think it would make sense to scale the intercept of the "injectionCurrent",
in addition to the scaling of "outputSlope", before sending it to the amplifier
for interpretation:

L53:    const float outputIntercept = 2386/gain_OUTPUT

This effectively (sic!) results in a rescaling of both the outputSlope and the outputIntercept
for injectionCurrent calculation:

L168:  injectionCurrent = (outputSlope * injectionCurrent + outputIntercept)/gain_OUTPUT;

To keep the code consistent, I have only made the change to L53.